### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package defines some colourful badges and boxes around text that represent user interface actions such as a click or following a menu.
 
-For examples have a look at the example [main.typ](./example/main.typ), [main.pdf](./exmaple/main.pdf).
+For examples have a look at the example [main.typ](./example/main.typ), [main.pdf](./example/main.pdf).
 
 ![example](./demo.png)
 


### PR DESCRIPTION
There is typo in the README file preventing users to view the example PDF file by clicking on the link.